### PR TITLE
Fix data truncation for user images

### DIFF
--- a/Backend/backend_code/src/main/java/onetomany/Users/UserImage.java
+++ b/Backend/backend_code/src/main/java/onetomany/Users/UserImage.java
@@ -13,6 +13,7 @@ public class UserImage {
 
     @Lob
     @Basic(fetch = FetchType.LAZY)
+    @Column(name = "data", columnDefinition = "LONGBLOB")
     private byte[] data;
 
     private String contentType;


### PR DESCRIPTION
## Summary
- ensure the user image data column uses a LONGBLOB to handle large uploads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e587bbef00832bbfa04ac0159b727a